### PR TITLE
 Fix for 'Exception in thread main java.lang.NoSuchMethodError: com.basho.riak.client.api.commands.datatypes.SetUpdate.add(Ljava/lang/String;)

### DIFF
--- a/src/main/java/com/basho/riak/client/api/commands/datatypes/SetUpdate.java
+++ b/src/main/java/com/basho/riak/client/api/commands/datatypes/SetUpdate.java
@@ -42,6 +42,20 @@ public class SetUpdate extends GSetUpdate
     {
     }
 
+    @Override
+    public SetUpdate add(BinaryValue value)
+    {
+        super.add(value);
+        return this;
+    }
+
+    @Override
+    public SetUpdate add(String value)
+    {
+        super.add(value);
+        return this;
+    }
+
     /**
      * Remove the provided value from the set in Riak.
      * @param value the value to be removed.


### PR DESCRIPTION
## Description
Fix for 'Exception in thread main java.lang.NoSuchMethodError: com.basho.riak.client.api.commands.datatypes.SetUpdate.add(Ljava/lang/String;)

## Motivation and Context
A breaking change was introduced to using `Sets` as support for `GSets` was added.
