### PR TITLE
Added parameter to Maven's javadoc plugin to allow comments containing scripts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,7 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
                             <additionalparam>-Xdoclint:none</additionalparam>
+                            <additionalparam>--allow-script-in-comments</additionalparam>
                             <excludePackageNames>com.basho.riak.protobuf.util</excludePackageNames>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
## Description
Added parameter to Maven's javadoc plugin to allow comments containing scripts.

## Related Issue
https://github.com/TI-Tokyo/riak-java-client/issues/3
